### PR TITLE
chore: scaffold extension build pipeline

### DIFF
--- a/image-cropper/package.json
+++ b/image-cropper/package.json
@@ -1,12 +1,13 @@
 {
   "name": "chrome-image-cropper",
   "version": "0.1.0",
-  "description": "Chrome extension for cropping images before download.",
+  "description": "Chrome extension scaffold for image cropping.",
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsup src/popup.ts --format=esm --sourcemap --clean --out-dir dist --watch",
-    "build": "tsup src/popup.ts --format=esm --sourcemap --minify --clean --out-dir dist",
+    "clean": "rimraf dist",
+    "dev": "pnpm clean && tsup --watch",
+    "build": "pnpm clean && tsup",
     "zip": "pnpm build && pnpm rimraf chrome-image-cropper.zip && cd dist && zip -r ../chrome-image-cropper.zip .",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write .",
@@ -15,14 +16,15 @@
   "devDependencies": {
     "@eslint/js": "^8.57.1",
     "@types/chrome": "^0.0.247",
+    "@types/node": "^20.16.11",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.2.5",
-    "tsup": "^8.0.2",
-    "typescript": "^5.4.5",
     "rimraf": "^5.0.5",
+    "tsup": "^8.0.2",
+    "typescript": "5.5.4",
     "typescript-eslint": "^7.8.0"
   }
 }

--- a/image-cropper/pnpm-lock.yaml
+++ b/image-cropper/pnpm-lock.yaml
@@ -14,12 +14,15 @@ importers:
       '@types/chrome':
         specifier: ^0.0.247
         version: 0.0.247
+      '@types/node':
+        specifier: ^20.16.11
+        version: 20.19.19
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.8.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: ^7.8.0
-        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+        version: 7.18.0(eslint@8.57.1)(typescript@5.5.4)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -34,13 +37,13 @@ importers:
         version: 5.0.10
       tsup:
         specifier: ^8.0.2
-        version: 8.5.0(typescript@5.9.3)
+        version: 8.5.0(typescript@5.5.4)
       typescript:
-        specifier: ^5.4.5
-        version: 5.9.3
+        specifier: 5.5.4
+        version: 5.5.4
       typescript-eslint:
         specifier: ^7.8.0
-        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+        version: 7.18.0(eslint@8.57.1)(typescript@5.5.4)
 
 packages:
 
@@ -388,6 +391,9 @@ packages:
 
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
+
+  '@types/node@20.19.19':
+    resolution: {integrity: sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -1107,13 +1113,16 @@ packages:
       typescript:
         optional: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1382,34 +1391,38 @@ snapshots:
 
   '@types/har-format@1.2.16': {}
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@types/node@20.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -1418,21 +1431,21 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.5.4)
       debug: 4.4.3
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@7.18.0': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -1441,18 +1454,18 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -2080,13 +2093,13 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@1.4.3(typescript@5.9.3):
+  ts-api-utils@1.4.3(typescript@5.5.4):
     dependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.0(typescript@5.9.3):
+  tsup@8.5.0(typescript@5.5.4):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.10)
       cac: 6.7.14
@@ -2106,7 +2119,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -2119,20 +2132,22 @@ snapshots:
 
   type-fest@0.20.2: {}
 
-  typescript-eslint@7.18.0(eslint@8.57.1)(typescript@5.9.3):
+  typescript-eslint@7.18.0(eslint@8.57.1)(typescript@5.5.4):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.5.4)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.5.4)
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@5.5.4: {}
 
   ufo@1.6.1: {}
+
+  undici-types@6.21.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/image-cropper/src/popup.html
+++ b/image-cropper/src/popup.html
@@ -7,13 +7,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main id="app">
-      <h1>Image Cropper</h1>
-      <p>Select an image to begin cropping.</p>
-      <input id="fileInput" type="file" accept="image/*" />
-      <button id="downloadButton" type="button" disabled>Download</button>
-      <button id="resetButton" type="button">Reset</button>
-    </main>
+    <main id="app" aria-live="polite"></main>
     <script type="module" src="popup.js"></script>
   </body>
 </html>

--- a/image-cropper/src/popup.ts
+++ b/image-cropper/src/popup.ts
@@ -1,30 +1,11 @@
 const appRoot = document.querySelector<HTMLDivElement>('#app');
-const fileInput = document.querySelector<HTMLInputElement>('#fileInput');
-const downloadButton = document.querySelector<HTMLButtonElement>('#downloadButton');
-const resetButton = document.querySelector<HTMLButtonElement>('#resetButton');
+
+if (!appRoot) {
+  throw new Error('Missing #app element in popup.html');
+}
 
 const initialize = (): void => {
-  if (!appRoot || !fileInput || !downloadButton || !resetButton) {
-    console.error('Popup markup missing required elements.');
-    return;
-  }
-
-  const handleReset = (): void => {
-    fileInput.value = '';
-    downloadButton.disabled = true;
-  };
-
-  const handleFileSelection = (): void => {
-    if (!fileInput.files || fileInput.files.length === 0) {
-      downloadButton.disabled = true;
-      return;
-    }
-
-    downloadButton.disabled = false;
-  };
-
-  fileInput.addEventListener('change', handleFileSelection);
-  resetButton.addEventListener('click', handleReset);
+  appRoot.textContent = '';
 };
 
-document.addEventListener('DOMContentLoaded', initialize);
+initialize();

--- a/image-cropper/src/styles.css
+++ b/image-cropper/src/styles.css
@@ -5,19 +5,16 @@
 
 body {
   margin: 0;
-  padding: 1.5rem;
-  background-color: #111827;
-  color: #f9fafb;
   min-width: 320px;
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #0f172a;
+  color: #f8fafc;
 }
 
-button:focus-visible,
-input:focus-visible {
-  outline: 3px solid #60a5fa;
-  outline-offset: 2px;
-}
-
-button[disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
+main {
+  width: 100%;
+  height: 100%;
 }

--- a/image-cropper/tsconfig.json
+++ b/image-cropper/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "lib": ["ES2020", "DOM"],
     "strict": true,
     "noEmit": true,

--- a/image-cropper/tsup.config.ts
+++ b/image-cropper/tsup.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'tsup';
+import { copyFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = fileURLToPath(new URL('.', import.meta.url));
+const distDir = path.resolve(projectRoot, 'dist');
+const staticFiles = ['manifest.json', 'popup.html', 'styles.css'];
+
+const copyStaticAssets = async (): Promise<void> => {
+  await mkdir(distDir, { recursive: true });
+
+  await Promise.all(
+    staticFiles.map((file) =>
+      copyFile(path.resolve(projectRoot, 'src', file), path.resolve(distDir, file))
+    )
+  );
+};
+
+export default defineConfig(({ watch }) => ({
+  entry: ['src/popup.ts'],
+  format: ['esm'],
+  sourcemap: true,
+  clean: true,
+  target: 'es2020',
+  outDir: 'dist',
+  splitting: false,
+  minify: !watch,
+  treeshake: true,
+  esbuildPlugins: [
+    {
+      name: 'copy-static-assets',
+      setup(build) {
+        build.onEnd(async (result) => {
+          if (result.errors.length === 0) {
+            await copyStaticAssets();
+          }
+        });
+      }
+    }
+  ]
+}));


### PR DESCRIPTION
## Summary
- scaffold the MV3 popup HTML, stylesheet, and TypeScript entry for a blank starting point
- add a tsup configuration that bundles popup.ts and copies static assets into dist
- update scripts and TypeScript settings to drive dev/build/typecheck workflows

## Testing
- pnpm typecheck
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dff417da78833289b12670cbfe4361