### PR TITLE
Add image preview UI to popup

### DIFF
--- a/image-cropper/src/popup.html
+++ b/image-cropper/src/popup.html
@@ -7,7 +7,23 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main id="app" aria-live="polite"></main>
+    <main id="app" aria-live="polite">
+      <form id="image-form" class="controls" aria-label="Image controls">
+        <label for="image-input">Choose an image</label>
+        <input id="image-input" type="file" accept="image/*" />
+      </form>
+      <canvas
+        id="image-canvas"
+        width="360"
+        height="240"
+        role="img"
+        aria-label="Selected image preview"
+      ></canvas>
+      <div class="actions">
+        <button type="button" id="reset-button">Reset</button>
+        <button type="button" id="download-button" disabled>Download</button>
+      </div>
+    </main>
     <script type="module" src="popup.js"></script>
   </body>
 </html>

--- a/image-cropper/src/popup.ts
+++ b/image-cropper/src/popup.ts
@@ -4,8 +4,136 @@ if (!appRoot) {
   throw new Error('Missing #app element in popup.html');
 }
 
+const fileInput = appRoot.querySelector<HTMLInputElement>('#image-input');
+const canvas = appRoot.querySelector<HTMLCanvasElement>('#image-canvas');
+const resetButton = appRoot.querySelector<HTMLButtonElement>('#reset-button');
+const downloadButton = appRoot.querySelector<HTMLButtonElement>('#download-button');
+
+if (!fileInput || !canvas || !resetButton || !downloadButton) {
+  throw new Error('Popup markup is missing required elements');
+}
+
+const context = canvas.getContext('2d');
+
+if (!context) {
+  throw new Error('Failed to acquire 2D context for canvas');
+}
+
+let hasImageLoaded = false;
+let currentScaleFactor = 1;
+
+const setDownloadState = (enabled: boolean): void => {
+  downloadButton.disabled = !enabled;
+};
+
+const clearCanvas = (): void => {
+  context.clearRect(0, 0, canvas.width, canvas.height);
+};
+
+const resetState = (): void => {
+  hasImageLoaded = false;
+  currentScaleFactor = 1;
+  delete canvas.dataset.scaleFactor;
+  clearCanvas();
+  setDownloadState(false);
+};
+
+const readImage = (file: File): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file);
+    const image = new Image();
+    image.decoding = 'async';
+
+    const handleLoad = (): void => {
+      URL.revokeObjectURL(objectUrl);
+      resolve(image);
+    };
+
+    const handleError = (): void => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('Unable to load the selected image'));
+    };
+
+    image.addEventListener('load', handleLoad, { once: true });
+    image.addEventListener('error', handleError, { once: true });
+    image.src = objectUrl;
+  });
+
+const drawImageToCanvas = async (file: File): Promise<void> => {
+  const image = await readImage(file);
+
+  const imageWidth = image.naturalWidth;
+  const imageHeight = image.naturalHeight;
+
+  if (imageWidth === 0 || imageHeight === 0) {
+    throw new Error('Invalid image dimensions');
+  }
+
+  const widthRatio = canvas.width / imageWidth;
+  const heightRatio = canvas.height / imageHeight;
+  const scale = Math.min(widthRatio, heightRatio);
+
+  const drawnWidth = imageWidth * scale;
+  const drawnHeight = imageHeight * scale;
+  const offsetX = (canvas.width - drawnWidth) / 2;
+  const offsetY = (canvas.height - drawnHeight) / 2;
+
+  clearCanvas();
+  context.drawImage(image, offsetX, offsetY, drawnWidth, drawnHeight);
+
+  currentScaleFactor = scale;
+  canvas.dataset.scaleFactor = String(currentScaleFactor);
+  hasImageLoaded = true;
+  setDownloadState(true);
+};
+
+const handleFileChange = async (event: Event): Promise<void> => {
+  const target = event.currentTarget as HTMLInputElement;
+  const { files } = target;
+
+  if (!files || files.length === 0) {
+    resetState();
+    return;
+  }
+
+  const file = files.item(0);
+
+  if (!file) {
+    resetState();
+    return;
+  }
+
+  if (!file.type.startsWith('image/')) {
+    resetState();
+    return;
+  }
+
+  try {
+    await drawImageToCanvas(file);
+  } catch (error) {
+    console.error(error);
+    resetState();
+  }
+};
+
+const handleReset = (): void => {
+  fileInput.value = '';
+  resetState();
+};
+
+const handleDownload = (): void => {
+  if (!hasImageLoaded) {
+    return;
+  }
+
+  // Download logic will be implemented alongside the cropper feature.
+};
+
 const initialize = (): void => {
-  appRoot.textContent = '';
+  resetState();
+  fileInput.addEventListener('change', handleFileChange);
+  resetButton.addEventListener('click', handleReset);
+  downloadButton.addEventListener('click', handleDownload);
 };
 
 initialize();


### PR DESCRIPTION
## Summary
- add image selection form, preview canvas, and action buttons to the popup UI
- render selected images scaled to fit the canvas and enable download when an image is present

## Testing
- pnpm typecheck
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dff65b639c8332ab6cfb7698a26a4d