### PR TITLE
Add interactive crop overlay

### DIFF
--- a/image-cropper/src/lib/cropper.ts
+++ b/image-cropper/src/lib/cropper.ts
@@ -1,28 +1,579 @@
-export type CropRegion = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+export type CropRect = {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
 };
 
-export const createInitialCropRegion = (imageWidth: number, imageHeight: number): CropRegion => {
-  const minSize = 32;
-  if (imageWidth < minSize || imageHeight < minSize) {
-    return {
-      x: 0,
-      y: 0,
-      width: Math.max(imageWidth, minSize),
-      height: Math.max(imageHeight, minSize)
-    };
+export type ImageMetrics = {
+  readonly naturalWidth: number;
+  readonly naturalHeight: number;
+  readonly drawnWidth: number;
+  readonly drawnHeight: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly scale: number;
+};
+
+export type CropperOptions = {
+  readonly minSize: number;
+  readonly onChange?: (crop: CropRect) => void;
+};
+
+export type Cropper = {
+  readonly setImageMetrics: (metrics: ImageMetrics) => void;
+  readonly setCrop: (crop: CropRect) => void;
+  readonly getCrop: () => CropRect | null;
+  readonly clear: () => void;
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (value < min) {
+    return min;
   }
 
-  const shorterSide = Math.min(imageWidth, imageHeight);
-  const size = Math.max(minSize, Math.floor(shorterSide * 0.5));
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+};
+
+type CropHandle = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw';
+
+type Interaction =
+  | {
+      readonly type: 'move';
+      readonly startPointer: DOMPointReadOnly;
+      readonly startCrop: CropRect;
+    }
+  | {
+      readonly type: 'resize';
+      readonly handle: CropHandle;
+      readonly startPointer: DOMPointReadOnly;
+      readonly startCrop: CropRect;
+    };
+
+type CanvasPoint = {
+  readonly x: number;
+  readonly y: number;
+};
+
+type DisplayRect = {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+type HandleRect = {
+  readonly handle: CropHandle;
+  readonly x: number;
+  readonly y: number;
+  readonly size: number;
+};
+
+const handleOrder: readonly CropHandle[] = [
+  'nw',
+  'n',
+  'ne',
+  'e',
+  'se',
+  's',
+  'sw',
+  'w',
+];
+
+const getCursorForHandle = (handle: CropHandle): string => {
+  if (handle === 'n' || handle === 's') {
+    return 'ns-resize';
+  }
+
+  if (handle === 'e' || handle === 'w') {
+    return 'ew-resize';
+  }
+
+  if (handle === 'ne' || handle === 'sw') {
+    return 'nesw-resize';
+  }
+
+  return 'nwse-resize';
+};
+
+const getCenterForHandle = (
+  handle: CropHandle,
+  rect: DisplayRect,
+): CanvasPoint => {
+  if (handle === 'nw') {
+    return { x: rect.x, y: rect.y };
+  }
+
+  if (handle === 'n') {
+    return { x: rect.x + rect.width / 2, y: rect.y };
+  }
+
+  if (handle === 'ne') {
+    return { x: rect.x + rect.width, y: rect.y };
+  }
+
+  if (handle === 'e') {
+    return { x: rect.x + rect.width, y: rect.y + rect.height / 2 };
+  }
+
+  if (handle === 'se') {
+    return { x: rect.x + rect.width, y: rect.y + rect.height };
+  }
+
+  if (handle === 's') {
+    return { x: rect.x + rect.width / 2, y: rect.y + rect.height };
+  }
+
+  if (handle === 'sw') {
+    return { x: rect.x, y: rect.y + rect.height };
+  }
+
+  return { x: rect.x, y: rect.y + rect.height / 2 };
+};
+
+export const createCropper = (
+  canvas: HTMLCanvasElement,
+  options: CropperOptions,
+): Cropper => {
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    throw new Error('Unable to obtain 2D context for crop overlay');
+  }
+
+  canvas.style.touchAction = 'none';
+
+  let metrics: ImageMetrics | null = null;
+  let crop: CropRect | null = null;
+  let interaction: Interaction | null = null;
+  let pointerId: number | null = null;
+  let rafId: number | null = null;
+  let handleRects: HandleRect[] = [];
+
+  const getMinWidth = (): number => {
+    if (!metrics) {
+      return options.minSize;
+    }
+
+    return Math.min(options.minSize, metrics.naturalWidth);
+  };
+
+  const getMinHeight = (): number => {
+    if (!metrics) {
+      return options.minSize;
+    }
+
+    return Math.min(options.minSize, metrics.naturalHeight);
+  };
+
+  const clearOverlay = (): void => {
+    context.clearRect(0, 0, canvas.width, canvas.height);
+  };
+
+  const notifyChange = (): void => {
+    if (!crop || !options.onChange) {
+      return;
+    }
+
+    options.onChange(crop);
+  };
+
+  const scheduleDraw = (): void => {
+    if (rafId !== null) {
+      return;
+    }
+
+    rafId = window.requestAnimationFrame(() => {
+      rafId = null;
+
+      if (!metrics || !crop) {
+        clearOverlay();
+        return;
+      }
+
+      const { offsetX, offsetY, scale } = metrics;
+      const displayX = offsetX + crop.x * scale;
+      const displayY = offsetY + crop.y * scale;
+      const displayWidth = crop.width * scale;
+      const displayHeight = crop.height * scale;
+      const rect: DisplayRect = {
+        x: displayX,
+        y: displayY,
+        width: displayWidth,
+        height: displayHeight,
+      };
+
+      handleRects = handleOrder.map((handle) => {
+        const center = getCenterForHandle(handle, rect);
+        const size = 12;
+        return {
+          handle,
+          x: center.x - size / 2,
+          y: center.y - size / 2,
+          size,
+        };
+      });
+
+      context.clearRect(0, 0, canvas.width, canvas.height);
+      context.save();
+      context.fillStyle = 'rgba(15, 23, 42, 0.55)';
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.clearRect(displayX, displayY, displayWidth, displayHeight);
+      context.restore();
+
+      context.save();
+      context.lineWidth = 2;
+      context.strokeStyle = '#38bdf8';
+      context.strokeRect(displayX + 1, displayY + 1, displayWidth - 2, displayHeight - 2);
+      context.restore();
+
+      context.save();
+      context.fillStyle = '#38bdf8';
+      context.strokeStyle = '#0f172a';
+      context.lineWidth = 1;
+      handleRects.forEach(({ x, y, size }) => {
+        context.fillRect(x, y, size, size);
+        context.strokeRect(x + 0.5, y + 0.5, size - 1, size - 1);
+      });
+      context.restore();
+    });
+  };
+
+  const sanitizeCrop = (rawCrop: CropRect): CropRect => {
+    if (!metrics) {
+      return rawCrop;
+    }
+
+    const maxWidth = metrics.naturalWidth;
+    const maxHeight = metrics.naturalHeight;
+    const minWidth = getMinWidth();
+    const minHeight = getMinHeight();
+
+    const width = clamp(rawCrop.width, minWidth, maxWidth);
+    const height = clamp(rawCrop.height, minHeight, maxHeight);
+    const x = clamp(rawCrop.x, 0, maxWidth - width);
+    const y = clamp(rawCrop.y, 0, maxHeight - height);
+
+    return {
+      x,
+      y,
+      width,
+      height,
+    };
+  };
+
+  const setCropInternal = (nextCrop: CropRect, shouldNotify: boolean): void => {
+    crop = sanitizeCrop(nextCrop);
+    scheduleDraw();
+
+    if (!shouldNotify) {
+      return;
+    }
+
+    notifyChange();
+  };
+
+  const canvasToImagePoint = ({ x, y }: CanvasPoint): DOMPointReadOnly => {
+    if (!metrics) {
+      return new DOMPointReadOnly(x, y);
+    }
+
+    const imageX = clamp(
+      (x - metrics.offsetX) / metrics.scale,
+      0,
+      metrics.naturalWidth,
+    );
+    const imageY = clamp(
+      (y - metrics.offsetY) / metrics.scale,
+      0,
+      metrics.naturalHeight,
+    );
+
+    return new DOMPointReadOnly(imageX, imageY);
+  };
+
+  const getPointerPosition = (event: PointerEvent): CanvasPoint => {
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: ((event.clientX - rect.left) * canvas.width) / rect.width,
+      y: ((event.clientY - rect.top) * canvas.height) / rect.height,
+    };
+  };
+
+  const findHandleAtPoint = (point: CanvasPoint): CropHandle | null => {
+    if (!crop) {
+      return null;
+    }
+
+    const hitSize = 20;
+
+    for (const { handle, x, y } of handleRects) {
+      const centerX = x + 6;
+      const centerY = y + 6;
+      const half = hitSize / 2;
+
+      if (
+        point.x >= centerX - half &&
+        point.x <= centerX + half &&
+        point.y >= centerY - half &&
+        point.y <= centerY + half
+      ) {
+        return handle;
+      }
+    }
+
+    return null;
+  };
+
+  const isPointInsideCrop = (point: DOMPointReadOnly): boolean => {
+    if (!crop) {
+      return false;
+    }
+
+    const withinX = point.x >= crop.x && point.x <= crop.x + crop.width;
+    const withinY = point.y >= crop.y && point.y <= crop.y + crop.height;
+
+    return withinX && withinY;
+  };
+
+  const updateCursor = (event: PointerEvent): void => {
+    if (!metrics || !crop) {
+      canvas.style.cursor = 'default';
+      return;
+    }
+
+    const point = getPointerPosition(event);
+    const handle = findHandleAtPoint(point);
+
+    if (handle) {
+      canvas.style.cursor = getCursorForHandle(handle);
+      return;
+    }
+
+    const imagePoint = canvasToImagePoint(point);
+
+    if (isPointInsideCrop(imagePoint)) {
+      canvas.style.cursor = 'move';
+      return;
+    }
+
+    canvas.style.cursor = 'default';
+  };
+
+  const handlePointerDown = (event: PointerEvent): void => {
+    if (!metrics || !crop) {
+      return;
+    }
+
+    const point = getPointerPosition(event);
+    const handle = findHandleAtPoint(point);
+    const imagePoint = canvasToImagePoint(point);
+
+    if (handle) {
+      interaction = {
+        type: 'resize',
+        handle,
+        startPointer: imagePoint,
+        startCrop: crop,
+      };
+    } else if (isPointInsideCrop(imagePoint)) {
+      interaction = {
+        type: 'move',
+        startPointer: imagePoint,
+        startCrop: crop,
+      };
+    } else {
+      interaction = null;
+    }
+
+    if (!interaction) {
+      return;
+    }
+
+    pointerId = event.pointerId;
+    canvas.setPointerCapture(pointerId);
+    event.preventDefault();
+  };
+
+  const applyMove = (point: DOMPointReadOnly, start: Interaction): void => {
+    if (!crop || !metrics) {
+      return;
+    }
+
+    const deltaX = point.x - start.startPointer.x;
+    const deltaY = point.y - start.startPointer.y;
+    const maxX = metrics.naturalWidth - start.startCrop.width;
+    const maxY = metrics.naturalHeight - start.startCrop.height;
+
+    const nextX = clamp(start.startCrop.x + deltaX, 0, maxX);
+    const nextY = clamp(start.startCrop.y + deltaY, 0, maxY);
+
+    setCropInternal(
+      {
+        x: nextX,
+        y: nextY,
+        width: start.startCrop.width,
+        height: start.startCrop.height,
+      },
+      true,
+    );
+  };
+
+  const applyResize = (point: DOMPointReadOnly, start: Extract<Interaction, { type: 'resize' }>): void => {
+    if (!metrics) {
+      return;
+    }
+
+    const deltaX = point.x - start.startPointer.x;
+    const deltaY = point.y - start.startPointer.y;
+    let nextX = start.startCrop.x;
+    let nextY = start.startCrop.y;
+    let nextWidth = start.startCrop.width;
+    let nextHeight = start.startCrop.height;
+
+    const minWidth = getMinWidth();
+    const minHeight = getMinHeight();
+
+    if (start.handle === 'w' || start.handle === 'nw' || start.handle === 'sw') {
+      const minX = 0;
+      const maxX = start.startCrop.x + start.startCrop.width - minWidth;
+      const candidateX = clamp(start.startCrop.x + deltaX, minX, maxX);
+      const deltaApplied = candidateX - start.startCrop.x;
+      nextX = candidateX;
+      nextWidth = start.startCrop.width - deltaApplied;
+    }
+
+    if (start.handle === 'e' || start.handle === 'ne' || start.handle === 'se') {
+      const maxWidth = metrics.naturalWidth - start.startCrop.x;
+      const candidateWidth = clamp(
+        start.startCrop.width + deltaX,
+        minWidth,
+        maxWidth,
+      );
+      nextWidth = candidateWidth;
+    }
+
+    if (start.handle === 'n' || start.handle === 'ne' || start.handle === 'nw') {
+      const minY = 0;
+      const maxY = start.startCrop.y + start.startCrop.height - minHeight;
+      const candidateY = clamp(start.startCrop.y + deltaY, minY, maxY);
+      const deltaApplied = candidateY - start.startCrop.y;
+      nextY = candidateY;
+      nextHeight = start.startCrop.height - deltaApplied;
+    }
+
+    if (start.handle === 's' || start.handle === 'se' || start.handle === 'sw') {
+      const maxHeight = metrics.naturalHeight - start.startCrop.y;
+      const candidateHeight = clamp(
+        start.startCrop.height + deltaY,
+        minHeight,
+        maxHeight,
+      );
+      nextHeight = candidateHeight;
+    }
+
+    nextX = clamp(nextX, 0, metrics.naturalWidth - nextWidth);
+    nextY = clamp(nextY, 0, metrics.naturalHeight - nextHeight);
+
+    setCropInternal(
+      {
+        x: nextX,
+        y: nextY,
+        width: nextWidth,
+        height: nextHeight,
+      },
+      true,
+    );
+  };
+
+  const handlePointerMove = (event: PointerEvent): void => {
+    if (!interaction) {
+      updateCursor(event);
+      return;
+    }
+
+    if (pointerId !== event.pointerId) {
+      return;
+    }
+
+    const point = getPointerPosition(event);
+    const imagePoint = canvasToImagePoint(point);
+
+    if (interaction.type === 'move') {
+      applyMove(imagePoint, interaction);
+    } else {
+      applyResize(imagePoint, interaction);
+    }
+
+    event.preventDefault();
+  };
+
+  const endInteraction = (): void => {
+    if (pointerId !== null) {
+      canvas.releasePointerCapture(pointerId);
+    }
+
+    pointerId = null;
+    interaction = null;
+  };
+
+  const handlePointerUp = (event: PointerEvent): void => {
+    if (pointerId !== event.pointerId) {
+      return;
+    }
+
+    endInteraction();
+    event.preventDefault();
+  };
+
+  const handlePointerCancel = (event: PointerEvent): void => {
+    if (pointerId !== event.pointerId) {
+      return;
+    }
+
+    endInteraction();
+  };
+
+  const setImageMetrics = (nextMetrics: ImageMetrics): void => {
+    metrics = nextMetrics;
+
+    if (crop) {
+      crop = sanitizeCrop(crop);
+    }
+
+    canvas.style.cursor = 'default';
+    scheduleDraw();
+  };
+
+  const setCrop = (nextCrop: CropRect): void => {
+    setCropInternal(nextCrop, true);
+  };
+
+  const getCrop = (): CropRect | null => crop;
+
+  const clear = (): void => {
+    endInteraction();
+    metrics = null;
+    crop = null;
+    handleRects = [];
+    canvas.style.cursor = 'default';
+    clearOverlay();
+  };
+
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointerleave', handlePointerUp);
+  canvas.addEventListener('pointercancel', handlePointerCancel);
 
   return {
-    x: Math.floor((imageWidth - size) / 2),
-    y: Math.floor((imageHeight - size) / 2),
-    width: size,
-    height: size
+    setImageMetrics,
+    setCrop,
+    getCrop,
+    clear,
   };
 };

--- a/image-cropper/src/styles.css
+++ b/image-cropper/src/styles.css
@@ -18,3 +18,59 @@ main {
   width: 100%;
   height: 100%;
 }
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.canvas-wrapper {
+  position: relative;
+  width: 360px;
+  height: 240px;
+  margin-block: 1rem;
+}
+
+.canvas-wrapper canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+}
+
+#image-canvas {
+  background: rgba(15, 23, 42, 0.8);
+}
+
+#crop-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: auto;
+  border-radius: 0.5rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(30, 41, 59, 0.7);
+  color: inherit;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- create a reusable cropper module that renders the crop rectangle and handles pointer interactions
- integrate the cropper overlay into the popup and initialize crop state for loaded images
- refresh popup styling to support the overlay canvas and improve control layout

## Testing
- pnpm typecheck
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dff8d8f8c48332bddcea609ac5a08f