### PR TITLE
Add download export controls for cropped images

### DIFF
--- a/image-cropper/src/popup.html
+++ b/image-cropper/src/popup.html
@@ -21,6 +21,11 @@
       ></canvas>
       <div class="actions">
         <button type="button" id="reset-button">Reset</button>
+        <label class="format-picker" for="format-select">Format</label>
+        <select id="format-select" aria-label="Download format">
+          <option value="image/png">PNG</option>
+          <option value="image/jpeg">JPEG</option>
+        </select>
         <button type="button" id="download-button" disabled>Download</button>
       </div>
     </main>

--- a/image-cropper/src/popup.ts
+++ b/image-cropper/src/popup.ts
@@ -10,8 +10,9 @@ const fileInput = appRoot.querySelector<HTMLInputElement>('#image-input');
 const canvas = appRoot.querySelector<HTMLCanvasElement>('#image-canvas');
 const resetButton = appRoot.querySelector<HTMLButtonElement>('#reset-button');
 const downloadButton = appRoot.querySelector<HTMLButtonElement>('#download-button');
+const formatSelect = appRoot.querySelector<HTMLSelectElement>('#format-select');
 
-if (!fileInput || !canvas || !resetButton || !downloadButton) {
+if (!fileInput || !canvas || !resetButton || !downloadButton || !formatSelect) {
   throw new Error('Popup markup is missing required elements');
 }
 
@@ -51,8 +52,12 @@ let hasImageLoaded = false;
 let currentScaleFactor = 1;
 let currentImageMetrics: ImageMetrics | null = null;
 let currentCrop: CropRect | null = null;
+let currentImageElement: HTMLImageElement | null = null;
 
 const MIN_CROP_SIZE = 32;
+const DEFAULT_EXPORT_FORMAT = 'image/png' as const;
+
+type ExportFormat = 'image/png' | 'image/jpeg';
 
 const cropper = createCropper(overlayCanvas, {
   minSize: MIN_CROP_SIZE,
@@ -90,10 +95,12 @@ const resetState = (): void => {
   currentScaleFactor = 1;
   currentImageMetrics = null;
   currentCrop = null;
+  currentImageElement = null;
   delete canvas.dataset.scaleFactor;
   clearCanvas();
   cropper.clear();
   setDownloadState(false);
+  formatSelect.value = DEFAULT_EXPORT_FORMAT;
 };
 
 const readImage = (file: File): Promise<HTMLImageElement> =>
@@ -156,6 +163,7 @@ const drawImageToCanvas = async (file: File): Promise<void> => {
   currentScaleFactor = scale;
   canvas.dataset.scaleFactor = String(currentScaleFactor);
   hasImageLoaded = true;
+  currentImageElement = image;
   setDownloadState(true);
 };
 
@@ -193,12 +201,86 @@ const handleReset = (): void => {
   resetState();
 };
 
-const handleDownload = (): void => {
+const createDownloadLink = (blob: Blob, extension: string): void => {
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = `crop.${extension}`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(objectUrl);
+};
+
+const exportCrop = async (format: ExportFormat): Promise<void> => {
+  if (!currentCrop || !currentImageElement) {
+    return;
+  }
+
+  const tempCanvas = document.createElement('canvas');
+  const cropWidth = Math.max(1, Math.round(currentCrop.width));
+  const cropHeight = Math.max(1, Math.round(currentCrop.height));
+  const maxSourceX = Math.max(0, currentImageElement.naturalWidth - 1);
+  const maxSourceY = Math.max(0, currentImageElement.naturalHeight - 1);
+  const sourceX = Math.min(Math.max(0, Math.round(currentCrop.x)), maxSourceX);
+  const sourceY = Math.min(Math.max(0, Math.round(currentCrop.y)), maxSourceY);
+  const maxAvailableWidth = Math.max(1, currentImageElement.naturalWidth - sourceX);
+  const maxAvailableHeight = Math.max(1, currentImageElement.naturalHeight - sourceY);
+  const outputWidth = Math.min(cropWidth, maxAvailableWidth);
+  const outputHeight = Math.min(cropHeight, maxAvailableHeight);
+
+  tempCanvas.width = outputWidth;
+  tempCanvas.height = outputHeight;
+
+  const tempContext = tempCanvas.getContext('2d');
+
+  if (!tempContext) {
+    throw new Error('Failed to acquire 2D context for export canvas');
+  }
+
+  tempContext.drawImage(
+    currentImageElement,
+    sourceX,
+    sourceY,
+    outputWidth,
+    outputHeight,
+    0,
+    0,
+    outputWidth,
+    outputHeight,
+  );
+
+  const blob = await new Promise<Blob | null>((resolve) => {
+    tempCanvas.toBlob(
+      (result) => {
+        resolve(result);
+      },
+      format,
+      format === 'image/jpeg' ? 0.92 : undefined,
+    );
+  });
+
+  if (!blob) {
+    throw new Error('Failed to export cropped image');
+  }
+
+  const extension = format === 'image/png' ? 'png' : 'jpg';
+  createDownloadLink(blob, extension);
+};
+
+const handleDownload = async (): Promise<void> => {
   if (!hasImageLoaded || !currentCrop || !currentImageMetrics) {
     return;
   }
 
-  // Download logic will be implemented alongside the cropper feature.
+  const selectedFormat =
+    formatSelect.value === 'image/jpeg' ? ('image/jpeg' as const) : DEFAULT_EXPORT_FORMAT;
+
+  try {
+    await exportCrop(selectedFormat);
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 const initialize = (): void => {

--- a/image-cropper/src/styles.css
+++ b/image-cropper/src/styles.css
@@ -54,6 +54,7 @@ main {
 .actions {
   display: flex;
   gap: 0.5rem;
+  align-items: center;
 }
 
 button {
@@ -71,6 +72,23 @@ button:disabled {
 }
 
 button:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.format-picker {
+  font-size: 0.875rem;
+}
+
+select {
+  padding: 0.4rem 0.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(30, 41, 59, 0.7);
+  color: inherit;
+}
+
+select:focus-visible {
   outline: 2px solid #38bdf8;
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- add a format selector to the popup alongside the download button
- implement exporting the cropped region using a temporary canvas and blob download
- reset the popup state including the selected export format

## Testing
- pnpm typecheck
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dffcb870e8833285c531645a556906