### PR TITLE
Use downloads API for crop exports

### DIFF
--- a/image-cropper/src/manifest.json
+++ b/image-cropper/src/manifest.json
@@ -7,5 +7,5 @@
     "default_popup": "popup.html",
     "default_title": "Image Cropper"
   },
-  "permissions": []
+  "permissions": ["downloads"]
 }


### PR DESCRIPTION
## Summary
- use the chrome.downloads API to export cropped images from the popup and keep an anchor fallback
- request the downloads permission required for the downloads API

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e093b4d51c8332839ed30aa80117b9