### PR TITLE
Add MV3 background service worker

### DIFF
--- a/image-cropper/src/background.ts
+++ b/image-cropper/src/background.ts
@@ -1,0 +1,60 @@
+const dispatchToggleEvent = () => {
+  window.dispatchEvent(new CustomEvent('CROP_EXT::TOGGLE'));
+};
+
+chrome.action.onClicked.addListener(async (tab) => {
+  try {
+    if (!tab.id) {
+      return;
+    }
+
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: dispatchToggleEvent,
+    });
+  } catch (error) {
+    console.error('action.onClicked error:', error);
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  (async () => {
+    try {
+      if (message?.type === 'CROP_EXT::CAPTURE') {
+        const dataUrl = await chrome.tabs.captureVisibleTab({
+          format: 'png',
+        });
+
+        sendResponse({ ok: true, dataUrl });
+        return;
+      }
+
+      if (message?.type === 'CROP_EXT::DOWNLOAD') {
+        const { dataUrl, fileName } = message as {
+          dataUrl: string;
+          fileName?: string;
+        };
+
+        if (!dataUrl) {
+          throw new Error('Missing dataUrl for download');
+        }
+
+        await chrome.downloads.download({
+          url: dataUrl,
+          filename: fileName || `capture_${Date.now()}.png`,
+          saveAs: true,
+        });
+
+        sendResponse({ ok: true });
+        return;
+      }
+
+      sendResponse({ ok: false, error: 'Unsupported message type' });
+    } catch (error) {
+      console.error('background handler error:', error);
+      sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) });
+    }
+  })();
+
+  return true;
+});

--- a/image-cropper/src/manifest.json
+++ b/image-cropper/src/manifest.json
@@ -4,8 +4,11 @@
   "description": "Crop images before downloading them locally.",
   "version": "0.1.0",
   "action": {
-    "default_popup": "popup.html",
     "default_title": "Image Cropper"
   },
-  "permissions": []
+  "permissions": ["activeTab", "downloads", "scripting"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  }
 }

--- a/image-cropper/tsup.config.ts
+++ b/image-cropper/tsup.config.ts
@@ -18,7 +18,7 @@ const copyStaticAssets = async (): Promise<void> => {
 };
 
 export default defineConfig(({ watch }) => ({
-  entry: ['src/popup.ts'],
+  entry: ['src/popup.ts', 'src/background.ts'],
   format: ['esm'],
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
## Summary
- add a background service worker that toggles crop mode when the action icon is clicked
- implement capture and download message handlers for future content script integration
- bundle the background entry and enable required MV3 permissions in the manifest

## Testing
- pnpm install
- pnpm typecheck
- pnpm build
- pnpm zip

------
https://chatgpt.com/codex/tasks/task_e_68e09bf50d5883328bddc4dc58a6a8e3