### PR TITLE
Implement DPR-aware capture workflow

### DIFF
--- a/screen-capture/src/background.ts
+++ b/screen-capture/src/background.ts
@@ -1,0 +1,75 @@
+type CaptureMessage = { type: "CROP_EXT::CAPTURE" };
+type DownloadMessage = {
+  type: "CROP_EXT::DOWNLOAD";
+  dataUrl: unknown;
+  fileName?: unknown;
+};
+
+type CropMessage = CaptureMessage | DownloadMessage;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isCaptureMessage(message: Record<string, unknown>): message is CaptureMessage {
+  return message.type === "CROP_EXT::CAPTURE";
+}
+
+function isDownloadMessage(message: Record<string, unknown>): message is DownloadMessage {
+  return message.type === "CROP_EXT::DOWNLOAD";
+}
+
+chrome.runtime.onMessage.addListener(
+  (message: CropMessage | Record<string, unknown> | unknown, _sender: unknown, sendResponse: (response: unknown) => void) => {
+    if (!isRecord(message)) {
+      return;
+    }
+
+    if (isCaptureMessage(message)) {
+      (async () => {
+        try {
+          const dataUrl = await chrome.tabs.captureVisibleTab(undefined, {
+            format: "png",
+          });
+
+          sendResponse({ ok: true, dataUrl });
+        } catch (error) {
+          const errMsg = error instanceof Error ? error.message : String(error);
+          console.error("[CROP_EXT] capture error:", errMsg);
+          sendResponse({ ok: false, error: errMsg });
+        }
+      })();
+      return true;
+    }
+
+    if (isDownloadMessage(message)) {
+      (async () => {
+        try {
+          if (typeof message.dataUrl !== "string") {
+            throw new Error("Missing dataUrl");
+          }
+
+          const filename =
+            typeof message.fileName === "string" && message.fileName.length > 0
+              ? message.fileName
+              : `capture_${Date.now()}.png`;
+
+          await chrome.downloads.download({
+            url: message.dataUrl,
+            filename,
+            saveAs: true,
+          });
+
+          sendResponse({ ok: true });
+        } catch (error) {
+          const errMsg = error instanceof Error ? error.message : String(error);
+          console.error("[CROP_EXT] download error:", errMsg);
+          sendResponse({ ok: false, error: errMsg });
+        }
+      })();
+      return true;
+    }
+
+    return undefined;
+  },
+);

--- a/screen-capture/src/chrome.d.ts
+++ b/screen-capture/src/chrome.d.ts
@@ -1,0 +1,27 @@
+export {};
+
+declare global {
+  const chrome: {
+    runtime: {
+      sendMessage: (message: unknown) => Promise<unknown>;
+      onMessage: {
+        addListener(
+          callback: (
+            message: unknown,
+            sender: unknown,
+            sendResponse: (response: unknown) => void,
+          ) => void,
+        ): void;
+      };
+    };
+    tabs: {
+      captureVisibleTab: (
+        windowId?: number,
+        options?: { format?: "jpeg" | "png"; quality?: number },
+      ) => Promise<string>;
+    };
+    downloads: {
+      download: (options: { url: string; filename?: string; saveAs?: boolean }) => Promise<number>;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- request visible-tab screenshots from the background worker and crop them using the selection rectangle with DPR-aware math
- implement background handlers for capture and download requests to drive chrome.tabs.captureVisibleTab and downloads.download
- add minimal chrome ambient typings so the new async message flow typechecks cleanly

## Testing
- pnpm install
- pnpm typecheck
- pnpm build
- pnpm zip

------
https://chatgpt.com/codex/tasks/task_e_68e0a072e4b8833299256814e957bbf6