### PR TITLE
Add browser action to toggle crop overlay

### DIFF
--- a/screen-capture/manifest.json
+++ b/screen-capture/manifest.json
@@ -4,6 +4,15 @@
   "version": "0.0.1",
   "description": "Minimal MV3 setup for the Chrome Image Cropper extension.",
   "permissions": ["activeTab", "downloads", "scripting"],
+  "action": {
+    "default_title": "Toggle crop overlay",
+    "default_icon": {
+      "16": "public/icon-128.png",
+      "32": "public/icon-128.png",
+      "48": "public/icon-128.png",
+      "128": "public/icon-128.png"
+    }
+  },
   "background": {
     "service_worker": "background.js",
     "type": "module"
@@ -17,5 +26,13 @@
   ],
   "icons": {
     "128": "public/icon-128.png"
+  },
+  "commands": {
+    "toggle-crop-overlay": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Y"
+      },
+      "description": "Toggle the crop overlay"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add an extension action button and keyboard shortcut definition to the manifest
- register background listeners to dispatch the crop overlay toggle event when the action or shortcut is used

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e0e32688148332b3a079183f5d7fac