### PR TITLE
Separate build formats for background and content scripts

### DIFF
--- a/screen-capture/scripts/build.mjs
+++ b/screen-capture/scripts/build.mjs
@@ -14,12 +14,10 @@ const iconPath = resolve(distDir, 'public', 'icon-128.png');
 const iconBase64 =
   'iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABY0lEQVR4nO3UQRGAQBADwYNCH4LwhQPk4AFk7GO6FeQxlW1d37fqzukBc/bpAcwSQJwA4gQQJ4A4AcQJIE4AcQKIE0CcAOIEECeAOAHECSBOAHECiBNAnADiBBAngDgBxAkgTgBxAogTQJwA4gQQJ4A4AcQJIE4AcQKIE0CcAOIEECeAOAHECSBOAHHHWvf0hnnvM71gjAeIE0CcAOIEECeAOAHECSBOAHECiBNAnADiBBAngDgBxAkgTgBxAogTQJwA4gQQJ4A4AcQJIE4AcQKIE0CcAOIEECeAOAHECSBOAHECiBNAnADiBBAngDgBxAkgTgBxAogTQJwA4gQQJ4A4AcQJIE4AcQKIE0CcAOIEECeAOAHECSBOAHECiBNAnADiBBAngDgBxP0a/wYtkK0lNgAAAABJRU5ErkJggg==';
 
-const entryPoints = [
-  { in: resolve(rootDir, 'src/background.ts'), out: 'background' },
-  { in: resolve(rootDir, 'src/content.ts'), out: 'content' }
-];
+const backgroundEntry = resolve(rootDir, 'src/background.ts');
+const contentEntry = resolve(rootDir, 'src/content.ts');
 
-for (const { in: input } of entryPoints) {
+for (const input of [backgroundEntry, contentEntry]) {
   if (!existsSync(input)) {
     throw new Error(`Missing entry point: ${input}`);
   }
@@ -28,11 +26,24 @@ for (const { in: input } of entryPoints) {
 await emptyDir(distDir);
 
 await build({
-  entryPoints,
+  entryPoints: [backgroundEntry],
   bundle: true,
   format: 'esm',
   platform: 'browser',
-  outdir: distDir,
+  outfile: resolve(distDir, 'background.js'),
+  target: 'es2020',
+  logLevel: 'info',
+  sourcemap: false,
+  treeShaking: true,
+});
+
+await build({
+  entryPoints: [contentEntry],
+  bundle: true,
+  format: 'iife',
+  platform: 'browser',
+  globalName: 'cropExtContent',
+  outfile: resolve(distDir, 'content.js'),
   target: 'es2020',
   logLevel: 'info',
   sourcemap: false,

--- a/screen-capture/src/content.ts
+++ b/screen-capture/src/content.ts
@@ -472,5 +472,3 @@ window.addEventListener("CROP_EXT::TOGGLE", () => {
     mount();
   }
 });
-
-export {};


### PR DESCRIPTION
## Summary
- update the build script to bundle the background script as ESM and the content script as an IIFE, outputting both files in dist/
- remove the module-only export from the content script so the bundle emits no module syntax

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e0e6ca35b08332a089a28e6f3ac30e