### PR TITLE
Fix capture workflow to trigger downloads

### DIFF
--- a/screen-capture/manifest.json
+++ b/screen-capture/manifest.json
@@ -3,7 +3,7 @@
   "name": "Chrome Image Cropper (MVP)",
   "version": "0.0.1",
   "description": "Minimal MV3 setup for the Chrome Image Cropper extension.",
-  "permissions": ["activeTab", "downloads", "scripting"],
+  "permissions": ["activeTab", "downloads", "scripting", "tabCapture"],
   "action": {
     "default_title": "Toggle crop overlay",
     "default_icon": {

--- a/screen-capture/src/background.ts
+++ b/screen-capture/src/background.ts
@@ -96,7 +96,7 @@ chrome.runtime.onMessage.addListener(
           await chrome.downloads.download({
             url: message.dataUrl,
             filename,
-            saveAs: true,
+            saveAs: false,
           });
 
           sendResponse({ ok: true });

--- a/screen-capture/src/chrome.d.ts
+++ b/screen-capture/src/chrome.d.ts
@@ -19,9 +19,29 @@ declare global {
         windowId?: number,
         options?: { format?: "jpeg" | "png"; quality?: number },
       ) => Promise<string>;
+      query: (queryInfo: {
+        active?: boolean;
+        lastFocusedWindow?: boolean;
+      }) => Promise<Array<{ id?: number }>>;
     };
     downloads: {
       download: (options: { url: string; filename?: string; saveAs?: boolean }) => Promise<number>;
+    };
+    scripting: {
+      executeScript: (options: {
+        target: { tabId: number };
+        func: () => void;
+      }) => Promise<unknown>;
+    };
+    action: {
+      onClicked: {
+        addListener: (callback: (tab: { id?: number }) => void) => void;
+      };
+    };
+    commands: {
+      onCommand: {
+        addListener: (callback: (command: string) => void) => void;
+      };
     };
   };
 }

--- a/screen-capture/src/content.ts
+++ b/screen-capture/src/content.ts
@@ -1,3 +1,5 @@
+export {};
+
 type Rect = {
   x: number;
   y: number;


### PR DESCRIPTION
## Summary
- request the `tabCapture` permission so the background script can grab the current tab when Enter is pressed
- download cropped images without prompting the user and extend the local chrome typings for the APIs in use
- mark the content script as a module so its custom DOM event typings compile cleanly

## Testing
- pnpm typecheck
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e0e83c85cc8332a574a458a4c1f995