### PR TITLE
Ensure background responses await download operations

### DIFF
--- a/screen-capture/src/background.ts
+++ b/screen-capture/src/background.ts
@@ -58,29 +58,30 @@ chrome.commands.onCommand.addListener(async (command) => {
   }
 });
 
-chrome.runtime.onMessage.addListener((message: CropMessage | Record<string, unknown> | unknown) => {
+chrome.runtime.onMessage.addListener((message: CropMessage | Record<string, unknown> | unknown, _sender, sendResponse) => {
   if (!isRecord(message)) {
     return undefined;
   }
 
   if (isCaptureMessage(message)) {
-    return (async () => {
+    (async () => {
       try {
         const dataUrl = await chrome.tabs.captureVisibleTab(undefined, {
           format: "png",
         });
 
-        return { ok: true, dataUrl };
+        sendResponse({ ok: true, dataUrl });
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);
         console.error("[CROP_EXT] capture error:", errMsg);
-        return { ok: false, error: errMsg };
+        sendResponse({ ok: false, error: errMsg });
       }
     })();
+    return true;
   }
 
   if (isDownloadMessage(message)) {
-    return (async () => {
+    (async () => {
       try {
         if (typeof message.dataUrl !== "string") {
           throw new Error("Missing dataUrl");
@@ -97,13 +98,14 @@ chrome.runtime.onMessage.addListener((message: CropMessage | Record<string, unkn
           saveAs: false,
         });
 
-        return { ok: true };
+        sendResponse({ ok: true });
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);
         console.error("[CROP_EXT] download error:", errMsg);
-        return { ok: false, error: errMsg };
+        sendResponse({ ok: false, error: errMsg });
       }
     })();
+    return true;
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- respond to capture and download messages via sendResponse to keep the port open
- ensure async capture and download results propagate back to the content script

## Testing
- pnpm typecheck
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e0ed2e84588332b9806dae9bd9c301