### PR TITLE
Default overlay selection to full screen

### DIFF
--- a/screen-capture/src/content.ts
+++ b/screen-capture/src/content.ts
@@ -104,6 +104,15 @@ function ensureStyles() {
   document.head.appendChild(style);
 }
 
+function setFullScreenSelection() {
+  rect.x = 0;
+  rect.y = 0;
+  rect.w = window.innerWidth;
+  rect.h = window.innerHeight;
+  clampRectToViewport(rect);
+  hasSelection = true;
+}
+
 function mount() {
   if (overlay) {
     return;
@@ -141,8 +150,7 @@ function mount() {
   overlay.appendChild(box);
   document.body.appendChild(overlay);
 
-  hasSelection = false;
-  clampRectToViewport(rect);
+  setFullScreenSelection();
   render();
   overlay.focus({ preventScroll: true });
 


### PR DESCRIPTION
## Summary
- initialize the capture overlay selection to cover the full viewport when it opens
- reuse the viewport sizing helper to keep the selection bounded while tracking the full screen

## Testing
- pnpm typecheck
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e0f0d78b008332a2e7af9c874115b3