### PR TITLE
Add read-only leads API endpoints

### DIFF
--- a/sales-lead-snapshot/app/api/leads/[id]/route.ts
+++ b/sales-lead-snapshot/app/api/leads/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import type { Lead } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+
+export type LeadDetailResponse = {
+  data: Lead | null;
+  message?: string;
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+): Promise<NextResponse<LeadDetailResponse>> {
+  const lead = await prisma.lead.findUnique({
+    where: {
+      id: params.id
+    }
+  });
+
+  if (!lead) {
+    return NextResponse.json(
+      {
+        data: null,
+        message: "Lead not found"
+      },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ data: lead });
+}

--- a/sales-lead-snapshot/app/api/leads/route.ts
+++ b/sales-lead-snapshot/app/api/leads/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import type { Lead } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+
+export type LeadResponse = {
+  data: Lead[];
+};
+
+export async function GET(): Promise<NextResponse<LeadResponse>> {
+  const leads = await prisma.lead.findMany({
+    orderBy: {
+      createdAt: "desc"
+    }
+  });
+
+  return NextResponse.json({ data: leads });
+}


### PR DESCRIPTION
## Summary
- add a read-only `/api/leads` endpoint that returns leads ordered by newest first
- add a `/api/leads/[id]` endpoint that fetches a single lead and emits 404 json when missing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1e923f7d88332a83c5d670d1b0e83