### PR TITLE
feat: add read-only leads API routes

### DIFF
--- a/sales-lead-snapshot/app/api/leads/[id]/route.ts
+++ b/sales-lead-snapshot/app/api/leads/[id]/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
-import type { Lead } from "@prisma/client";
 
 import prisma from "@/lib/prisma";
 
+import type { LeadDto } from "../route";
+import { leadSelect, mapLeadToDto } from "../route";
+
 export type LeadDetailResponse = {
-  data: Lead | null;
+  data: LeadDto | null;
   message?: string;
 };
 
@@ -15,7 +17,8 @@ export async function GET(
   const lead = await prisma.lead.findUnique({
     where: {
       id: params.id
-    }
+    },
+    select: leadSelect
   });
 
   if (!lead) {
@@ -28,5 +31,5 @@ export async function GET(
     );
   }
 
-  return NextResponse.json({ data: lead });
+  return NextResponse.json({ data: mapLeadToDto(lead) });
 }

--- a/sales-lead-snapshot/app/api/leads/route.ts
+++ b/sales-lead-snapshot/app/api/leads/route.ts
@@ -1,18 +1,57 @@
 import { NextResponse } from "next/server";
-import type { Lead } from "@prisma/client";
+
+import type { Prisma } from "@prisma/client";
 
 import prisma from "@/lib/prisma";
 
-export type LeadResponse = {
-  data: Lead[];
+export type LeadDto = {
+  id: string;
+  createdAt: string;
+  imagePath: string;
+  sourceUrl: string | null;
+  name: string | null;
+  title: string | null;
+  company: string | null;
+  website: string | null;
+  domain: string | null;
+  location: string | null;
+  notes: string | null;
+  openerEmail: string | null;
 };
+
+export type LeadResponse = {
+  data: LeadDto[];
+};
+
+export const leadSelect = {
+  id: true,
+  createdAt: true,
+  imagePath: true,
+  sourceUrl: true,
+  name: true,
+  title: true,
+  company: true,
+  website: true,
+  domain: true,
+  location: true,
+  notes: true,
+  openerEmail: true
+} satisfies const;
+
+type LeadRecord = Prisma.LeadGetPayload<{ select: typeof leadSelect }>;
+
+export const mapLeadToDto = (lead: LeadRecord): LeadDto => ({
+  ...lead,
+  createdAt: lead.createdAt.toISOString()
+});
 
 export async function GET(): Promise<NextResponse<LeadResponse>> {
   const leads = await prisma.lead.findMany({
     orderBy: {
       createdAt: "desc"
-    }
+    },
+    select: leadSelect
   });
 
-  return NextResponse.json({ data: leads });
+  return NextResponse.json({ data: leads.map(mapLeadToDto) });
 }


### PR DESCRIPTION
## Summary
- add read-only list endpoint for leads ordered by creation date
- add read-only detail endpoint with 404 response when the lead is missing
- share DTO mapping between list and detail endpoints for consistent serialization

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1ea8e48688332876a53ba17a2dc92