### PR TITLE
feat: add PNG upload API and homepage integration

### DIFF
--- a/sales-lead-snapshot/app/api/upload/route.ts
+++ b/sales-lead-snapshot/app/api/upload/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { createId } from "@paralleldrive/cuid2";
+
+export const runtime = "nodejs";
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const ensureUploadDir = async (dir: string) => {
+  await fs.mkdir(dir, { recursive: true });
+};
+
+const isPng = (buffer: Buffer, mimeType: string | undefined) => {
+  if (mimeType !== "image/png") {
+    return false;
+  }
+
+  return PNG_SIGNATURE.equals(buffer.subarray(0, PNG_SIGNATURE.length));
+};
+
+export async function POST(request: Request) {
+  try {
+    const contentType = request.headers.get("content-type") ?? "";
+
+    if (!contentType.includes("multipart/form-data")) {
+      return NextResponse.json({ error: "Invalid content type" }, { status: 400 });
+    }
+
+    const formData = await request.formData();
+    const file = formData.get("file");
+
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json({ error: "Missing file" }, { status: 400 });
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    if (!isPng(buffer, file.type)) {
+      return NextResponse.json({ error: "Only PNG files are supported" }, { status: 400 });
+    }
+
+    const uploadDir = path.join(process.cwd(), "public/uploads");
+    await ensureUploadDir(uploadDir);
+
+    const id = createId();
+    const filePath = path.join(uploadDir, `${id}.png`);
+    await fs.writeFile(filePath, buffer);
+
+    return NextResponse.json({ imagePath: `/uploads/${id}.png` });
+  } catch (error) {
+    console.error("Upload failed", error);
+    return NextResponse.json({ error: "Failed to upload file" }, { status: 500 });
+  }
+}

--- a/sales-lead-snapshot/app/page.tsx
+++ b/sales-lead-snapshot/app/page.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import type { ChangeEvent, DragEvent, KeyboardEvent } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -7,7 +12,100 @@ import {
   CardTitle
 } from "@/components/ui/card";
 
+type UploadState = {
+  imagePath: string;
+  createdAt: number;
+};
+
+const TOAST_DURATION_MS = 3000;
+
 export default function HomePage() {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [uploads, setUploads] = useState<UploadState[]>([]);
+
+  useEffect(() => {
+    if (!toastMessage) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setToastMessage(null), TOAST_DURATION_MS);
+
+    return () => clearTimeout(timeout);
+  }, [toastMessage]);
+
+  const handleUpload = useCallback(
+    async (file: File | null) => {
+      if (!file) {
+        return;
+      }
+
+      if (file.type !== "image/png") {
+        setErrorMessage("Only PNG files are supported.");
+        return;
+      }
+
+      setErrorMessage(null);
+      setIsUploading(true);
+
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const response = await fetch("/api/upload", {
+          method: "POST",
+          body: formData
+        });
+
+        if (!response.ok) {
+          throw new Error("Upload failed");
+        }
+
+        const data: { imagePath: string } = await response.json();
+        setUploads((current) => [
+          { imagePath: data.imagePath, createdAt: Date.now() },
+          ...current
+        ]);
+        setToastMessage("Uploaded");
+      } catch (error) {
+        console.error(error);
+        setErrorMessage("Something went wrong while uploading. Please try again.");
+      } finally {
+        setIsUploading(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+      }
+    },
+    []
+  );
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      void handleUpload(event.target.files?.[0] ?? null);
+    },
+    [handleUpload]
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const [file] = Array.from(event.dataTransfer.files);
+      void handleUpload(file ?? null);
+    },
+    [handleUpload]
+  );
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  }, []);
+
+  const handleButtonClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
   return (
     <div className="space-y-8">
       <section>
@@ -21,7 +119,21 @@ export default function HomePage() {
           <CardContent>
             <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
               <div className="flex flex-col gap-4">
-                <div className="flex flex-1 items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 bg-muted/40 p-10 text-center">
+                <div
+                  className="flex flex-1 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-muted-foreground/30 bg-muted/40 p-10 text-center"
+                  onClick={handleButtonClick}
+                  onDrop={handleDrop}
+                  onDragOver={handleDragOver}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      handleButtonClick();
+                    }
+                  }}
+                  aria-label="Upload PNG screenshot"
+                >
                   <div className="space-y-2">
                     <p className="text-sm font-medium text-muted-foreground">
                       Drop your PNG screenshot here
@@ -34,8 +146,22 @@ export default function HomePage() {
                 <p className="text-xs text-muted-foreground">
                   PNG files up to 10MB are supported. Upload processing will be added soon.
                 </p>
+                {errorMessage ? (
+                  <p className="text-xs text-destructive">{errorMessage}</p>
+                ) : null}
               </div>
-              <Button className="md:self-start">Choose file</Button>
+              <div className="flex flex-col items-stretch gap-2 md:self-start">
+                <Button onClick={handleButtonClick} disabled={isUploading}>
+                  {isUploading ? "Uploading..." : "Choose file"}
+                </Button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png"
+                  className="hidden"
+                  onChange={handleFileChange}
+                />
+              </div>
             </div>
           </CardContent>
         </Card>
@@ -51,13 +177,43 @@ export default function HomePage() {
             Export CSV
           </Button>
         </div>
-        <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-muted-foreground/40 bg-background py-14 text-center">
-          <p className="text-sm font-medium text-muted-foreground">No leads yet</p>
-          <p className="max-w-md text-sm text-muted-foreground/80">
-            Upload a screenshot to let the agents extract contact details and craft a personalized outreach email.
-          </p>
-        </div>
+        {uploads.length > 0 ? (
+          <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {uploads.map((upload) => (
+              <li
+                key={`${upload.imagePath}-${upload.createdAt}`}
+                className="flex flex-col gap-3 rounded-lg border bg-muted/30 p-4"
+              >
+                <div className="relative aspect-video overflow-hidden rounded-md bg-muted">
+                  <Image
+                    src={upload.imagePath}
+                    alt="Uploaded screenshot"
+                    fill
+                    sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                    className="object-cover"
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {new Date(upload.createdAt).toLocaleTimeString()}
+                </p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-muted-foreground/40 bg-background py-14 text-center">
+            <p className="text-sm font-medium text-muted-foreground">No leads yet</p>
+            <p className="max-w-md text-sm text-muted-foreground/80">
+              Upload a screenshot to let the agents extract contact details and craft a personalized outreach email.
+            </p>
+          </div>
+        )}
       </section>
+
+      {toastMessage ? (
+        <div className="fixed bottom-6 right-6 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background shadow-lg">
+          {toastMessage}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/sales-lead-snapshot/package.json
+++ b/sales-lead-snapshot/package.json
@@ -13,6 +13,7 @@
     "db:migrate": "prisma migrate dev --name init"
   },
   "dependencies": {
+    "@paralleldrive/cuid2": "^2.2.2",
     "@prisma/client": "5.14.0",
     "@radix-ui/react-slot": "^1.0.4",
     "clsx": "^2.1.0",

--- a/sales-lead-snapshot/pnpm-lock.yaml
+++ b/sales-lead-snapshot/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@paralleldrive/cuid2':
+        specifier: ^2.2.2
+        version: 2.2.2
       '@prisma/client':
         specifier: 5.14.0
         version: 5.14.0(prisma@5.14.0)
@@ -194,6 +197,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -209,6 +216,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@paralleldrive/cuid2@2.2.2':
+    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1949,6 +1959,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.5':
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1962,6 +1974,10 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@paralleldrive/cuid2@2.2.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
## Summary
- add a POST /api/upload API route that validates PNG uploads and saves them to public/uploads with cuid file names
- wire the homepage uploader to call the new endpoint, show a toast, and render a preview list of uploads
- include the cuid2 dependency needed for generating ids

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1eb6b055c8332bb12c1d6c676b568