### PR TITLE
Add app directory path alias to TypeScript config

### DIFF
--- a/sales-lead-snapshot/tsconfig.json
+++ b/sales-lead-snapshot/tsconfig.json
@@ -22,6 +22,9 @@
       "node"
     ],
     "paths": {
+      "@/app/*": [
+        "./app/*"
+      ],
       "@/components/*": [
         "./components/*"
       ],


### PR DESCRIPTION
## Summary
- add an @/app path alias to the TypeScript configuration so imports from the app directory resolve correctly

## Testing
- pnpm typecheck *(fails: requires generated Prisma client and additional dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23153dbc483328a5acc1ca9dc03bb