### PR TITLE
Ensure Prisma client generation during build

### DIFF
--- a/sales-lead-snapshot/package.json
+++ b/sales-lead-snapshot/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- update the build script to run `prisma generate` before `next build`

## Testing
- `pnpm db:generate` *(fails: Prisma engine download blocked by 403 Forbidden in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2356991148332afdcde7bbe766a4c