### PR TITLE
Add Prisma generate predev hook

### DIFF
--- a/sales-lead-snapshot/package.json
+++ b/sales-lead-snapshot/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "pnpm db:generate",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Summary
- add a predev script that runs `pnpm db:generate` so Prisma clients are generated before starting the dev server

## Testing
- pnpm run dev *(fails: Prisma engine download returns 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e237100cb083328228221831664c8e