### PR TITLE
Fix upload flow to align with API

### DIFF
--- a/sales-lead-snapshot/app/page.tsx
+++ b/sales-lead-snapshot/app/page.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card";
+import type { LeadDto } from "@/app/api/leads/route";
 
 type UploadState = {
   imagePath: string;
@@ -63,7 +64,7 @@ export default function HomePage() {
           throw new Error("Upload failed");
         }
 
-        const data: { imagePath: string } = await response.json();
+        const { data }: { data: LeadDto } = await response.json();
         setUploads((current) => [
           { imagePath: data.imagePath, createdAt: Date.now() },
           ...current

--- a/sales-lead-snapshot/lib/ai.ts
+++ b/sales-lead-snapshot/lib/ai.ts
@@ -107,7 +107,7 @@ export const extractLeadFromImage = async ({
           },
           {
             type: "input_image",
-            image_base64: imageBase64
+            image_url: `data:image/png;base64,${imageBase64}`
           }
         ]
       }


### PR DESCRIPTION
## Summary
- update the OpenAI Responses call to send image data using a data URL instead of the unsupported image_base64 field
- adjust the upload handler on the client to read the { data: LeadDto } response shape

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23b0ab78483329c168a7cc7b4446e