### PR TITLE
Fix OpenAI Responses API JSON schema configuration

### DIFF
--- a/sales-lead-snapshot/lib/ai.ts
+++ b/sales-lead-snapshot/lib/ai.ts
@@ -112,9 +112,9 @@ export const extractLeadFromImage = async ({
         ]
       }
     ],
-    response_format: {
-      type: "json_schema",
-      json_schema: {
+    text: {
+      format: {
+        type: "json_schema",
         name: "lead_extraction_result",
         schema: leadSchema
       }


### PR DESCRIPTION
## Summary
- update the lead extraction call to use the new `text.format` field required by the Responses API
- keep the existing JSON schema while ensuring compatibility with the latest OpenAI client

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e23d889a148332b33d48e8e989092a