### PR TITLE
Allow PNG uploads without MIME metadata

### DIFF
--- a/sales-lead-snapshot/app/api/upload/route.ts
+++ b/sales-lead-snapshot/app/api/upload/route.ts
@@ -20,7 +20,17 @@ const ensureUploadDir = async (dir: string) => {
 };
 
 const isPng = (buffer: Buffer, mimeType: string | undefined) => {
-  if (mimeType !== "image/png") {
+  const normalizedMimeType = mimeType?.toLowerCase();
+  const hasValidMimeType =
+    !normalizedMimeType ||
+    normalizedMimeType === "image/png" ||
+    normalizedMimeType === "image/x-png";
+
+  if (!hasValidMimeType) {
+    return false;
+  }
+
+  if (buffer.length < PNG_SIGNATURE.length) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- allow PNG uploads to pass validation when the browser omits or varies the MIME type while still requiring the PNG signature
- guard against undersized buffers before comparing the PNG header

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e243e557688332a82cfe72d05fc8bd