### PR TITLE
Add optional lead dedupe using embeddings

### DIFF
--- a/sales-lead-snapshot/app/api/upload/route.ts
+++ b/sales-lead-snapshot/app/api/upload/route.ts
@@ -4,7 +4,8 @@ import path from "path";
 import { createId } from "@paralleldrive/cuid2";
 
 import { mapLeadToDto, leadSelect } from "@/app/api/leads/route";
-import { extractLeadFromImage, generateOpenerEmail } from "@/lib/ai";
+import { embedLeadCanonical, extractLeadFromImage, generateOpenerEmail } from "@/lib/ai";
+import { cosine } from "@/lib/cosine";
 import prisma from "@/lib/prisma";
 
 import type { Lead } from "@prisma/client";
@@ -39,6 +40,18 @@ const isPng = (buffer: Buffer, mimeType: string | undefined) => {
 
 type UploadResponse = { data: LeadDto };
 
+const bufferToFloat32Array = (bytes: Uint8Array): Float32Array => {
+  const arrayBuffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  );
+
+  return new Float32Array(arrayBuffer);
+};
+
+const float32ArrayToBuffer = (array: Float32Array): Buffer =>
+  Buffer.from(array.buffer, array.byteOffset, array.byteLength);
+
 export async function POST(request: Request) {
   try {
     const contentType = request.headers.get("content-type") ?? "";
@@ -48,6 +61,16 @@ export async function POST(request: Request) {
     }
 
     const formData = await request.formData();
+    const url = new URL(request.url);
+
+    const dedupeValues = [url.searchParams.get("dedupe"), formData.get("dedupe")]
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim().toLowerCase());
+
+    const dedupeRequested = dedupeValues.some(
+      (value) => value === "1" || value === "true"
+    );
+
     const file = formData.get("file");
 
     if (!file || !(file instanceof File)) {
@@ -84,6 +107,7 @@ export async function POST(request: Request) {
       typeof process.env.OPENAI_API_KEY === "string" && process.env.OPENAI_API_KEY.trim().length > 0;
 
     let extracted: Partial<Lead> = {};
+    let embedding: Float32Array | null = null;
 
     if (hasOpenAiKey) {
       try {
@@ -94,15 +118,61 @@ export async function POST(request: Request) {
       } catch (error) {
         console.error("Lead extraction failed", error);
       }
+
+      try {
+        embedding = await embedLeadCanonical({
+          name: extracted.name ?? null,
+          title: extracted.title ?? null,
+          company: extracted.company ?? null,
+          domain: extracted.domain ?? null
+        });
+      } catch (error) {
+        console.error("Failed to compute lead embedding", error);
+      }
     } else {
       console.warn("Skipping lead extraction because OPENAI_API_KEY is not set");
+    }
+
+    if (dedupeRequested && embedding) {
+      const candidates = await prisma.lead.findMany({
+        where: { embedding: { not: null } },
+        select: { id: true, embedding: true }
+      });
+
+      let bestMatch: { id: string; similarity: number } | null = null;
+
+      for (const candidate of candidates) {
+        if (!candidate.embedding) {
+          continue;
+        }
+
+        const candidateEmbedding = bufferToFloat32Array(candidate.embedding);
+        const similarity = cosine(embedding, candidateEmbedding);
+
+        if (!bestMatch || similarity > bestMatch.similarity) {
+          bestMatch = { id: candidate.id, similarity };
+        }
+      }
+
+      if (bestMatch && bestMatch.similarity >= 0.9) {
+        try {
+          await fs.unlink(filePath);
+        } catch (error) {
+          console.warn("Failed to cleanup duplicate upload", error);
+        }
+
+        return NextResponse.json({ duplicateOf: bestMatch.id });
+      }
+    } else if (dedupeRequested && !embedding) {
+      console.warn("Deduplication requested but embedding could not be computed");
     }
 
     const createdLead = await prisma.lead.create({
       data: {
         imagePath,
         sourceUrl,
-        ...extracted
+        ...extracted,
+        embedding: embedding ? float32ArrayToBuffer(embedding) : undefined
       }
     });
 

--- a/sales-lead-snapshot/lib/cosine.ts
+++ b/sales-lead-snapshot/lib/cosine.ts
@@ -1,0 +1,26 @@
+export const cosine = (a: Float32Array, b: Float32Array): number => {
+  const length = Math.min(a.length, b.length);
+
+  if (length === 0) {
+    return 0;
+  }
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < length; i += 1) {
+    const valueA = a[i];
+    const valueB = b[i];
+
+    dot += valueA * valueB;
+    normA += valueA * valueA;
+    normB += valueB * valueB;
+  }
+
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+};

--- a/sales-lead-snapshot/readme.md
+++ b/sales-lead-snapshot/readme.md
@@ -113,6 +113,12 @@ Click Copy email or Export CSV to download all leads.
 | `/api/leads/:id`  | `GET`  | Lead detail                           |
 | `/api/export.csv` | `GET`  | Export all leads as CSV               |
 
+### Optional Deduplication
+
+- Append `?dedupe=1` to the upload request URL **or** include a form field `dedupe=true` to enable duplicate detection.
+- The API computes embeddings for the lead's canonical string (`name|title|company|domain`) and compares against stored leads using cosine similarity.
+- If the highest similarity is >= 0.90, the API responds with `{ duplicateOf: <leadId> }` and skips creating a new record.
+
 
 ## 📁 File Structure
 


### PR DESCRIPTION
## Summary
- compute and store a canonical lead embedding with `text-embedding-3-small`
- add cosine similarity helper and optional dedupe check in the upload route
- document the `?dedupe=1` flag for deduplication in the README

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2487aaf0c83329c418d57c14e6c18