### PR TITLE
feat: add leads CSV export

### DIFF
--- a/sales-lead-snapshot/app/api/export.csv/route.ts
+++ b/sales-lead-snapshot/app/api/export.csv/route.ts
@@ -1,0 +1,66 @@
+import type { Prisma } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+
+const leadSelect = {
+  id: true,
+  createdAt: true,
+  name: true,
+  title: true,
+  company: true,
+  website: true,
+  domain: true,
+  location: true,
+  notes: true,
+  openerEmail: true
+} as const satisfies Prisma.LeadSelect;
+
+type LeadForExport = Prisma.LeadGetPayload<{ select: typeof leadSelect }>;
+
+const columns = [
+  "id",
+  "createdAt",
+  "name",
+  "title",
+  "company",
+  "website",
+  "domain",
+  "location",
+  "notes",
+  "openerEmail"
+] as const satisfies ReadonlyArray<keyof LeadForExport>;
+
+const escapeCsvValue = (value: string | Date | null): string => {
+  if (value === null) {
+    return "";
+  }
+
+  const stringValue =
+    value instanceof Date ? value.toISOString() : value.toString();
+  const escaped = stringValue.replace(/"/g, '""');
+
+  return `"${escaped}"`;
+};
+
+const mapLeadToRow = (lead: LeadForExport): string =>
+  columns.map((column) => escapeCsvValue(lead[column] ?? null)).join(",");
+
+export async function GET(): Promise<Response> {
+  const leads = await prisma.lead.findMany({
+    orderBy: {
+      createdAt: "desc"
+    },
+    select: leadSelect
+  });
+
+  const header = columns.join(",");
+  const rows = leads.map(mapLeadToRow);
+  const csv = [header, ...rows].join("\n");
+
+  return new Response(csv, {
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": 'attachment; filename="leads.csv"'
+    }
+  });
+}

--- a/sales-lead-snapshot/app/page.tsx
+++ b/sales-lead-snapshot/app/page.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import type { LeadDto, LeadResponse } from "@/app/api/leads/route";
 
 export default function HomePage() {
@@ -59,11 +60,16 @@ export default function HomePage() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight">Leads</h1>
-        <p className="text-sm text-muted-foreground">
-          Browse the latest leads generated from your uploaded screenshots.
-        </p>
+      <section className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Leads</h1>
+          <p className="text-sm text-muted-foreground">
+            Browse the latest leads generated from your uploaded screenshots.
+          </p>
+        </div>
+        <Button asChild className="w-full sm:w-auto">
+          <Link href="/api/export.csv">Export CSV</Link>
+        </Button>
       </section>
 
       <section className="space-y-4">


### PR DESCRIPTION
## Summary
- add an export.csv API route that streams all leads as CSV
- escape fields and set download headers for the generated CSV
- surface an Export CSV button on the home page to download the file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24c4ae4a8833296fbbeea8d2df702